### PR TITLE
Fixed issue where RavenOptions wasn't populated when passed into PostConfigure

### DIFF
--- a/RavenDB.DependencyInjection/RavenOptions.cs
+++ b/RavenDB.DependencyInjection/RavenOptions.cs
@@ -58,5 +58,19 @@ namespace Raven.DependencyInjection
         ///     </code>
         /// </example>
         public Action<IDocumentStore> BeforeInitializeDocStore { get; set; }
+
+        /// <summary>
+        /// Action executed on the document store after calling docStore.Initialize(...).
+        /// This should be used to register indexes.
+        /// </summary>
+        /// <example>
+        ///     <code>
+        ///         services.AddRavenDbDocStore(options =>
+        ///         {
+        ///             options.AfterInitializeDocStore = docStore => IndexCreation.CreateIndexes(Assembly.GetExecutingAssembly(), docStore);
+        ///         }
+        ///     </code>
+        /// </example>
+        public Action<IDocumentStore> AfterInitializeDocStore { get; set; }
     }
 }

--- a/RavenDB.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/RavenDB.DependencyInjection/ServiceCollectionExtensions.cs
@@ -38,7 +38,9 @@ namespace Raven.DependencyInjection
             services.AddSingleton(sp =>
             {
                 var setup = sp.GetRequiredService<IOptions<RavenOptions>>().Value;
-                return setup.GetDocumentStore(setup.BeforeInitializeDocStore);
+                var docStore = setup.GetDocumentStore(setup.BeforeInitializeDocStore);
+                setup.AfterInitializeDocStore(docStore);
+                return docStore;
             });
 
             return services;

--- a/RavenDB.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/RavenDB.DependencyInjection/ServiceCollectionExtensions.cs
@@ -33,8 +33,8 @@ namespace Raven.DependencyInjection
             this IServiceCollection services,
             Action<RavenOptions> options)
         {
-            services.ConfigureOptions<RavenOptionsSetup>();
             services.Configure(options);
+            services.ConfigureOptions<RavenOptionsSetup>();
             services.AddSingleton(sp =>
             {
                 var setup = sp.GetRequiredService<IOptions<RavenOptions>>().Value;

--- a/Sample/Startup.cs
+++ b/Sample/Startup.cs
@@ -27,7 +27,10 @@ namespace Sample
         {
             // Configure Raven in 2 steps:
             services
-                .AddRavenDbDocStore() // 1. Configures Raven connection using the settings in appsettings.json.
+                .AddRavenDbDocStore(options =>
+                {
+                    options.SectionName = "ravendb";
+                }) // 1. Configures Raven connection using the settings in appsettings.json.
                 .AddRavenDbAsyncSession(); // 2. Add a scoped IAsyncDocumentSession. For the sync version, use .AddRavenSession() instead.
 
             // For demo purposes, create an OrderService. We'll use it in the UI, see Index.cshtml

--- a/Sample/appsettings.json
+++ b/Sample/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "RavenSettings": {
+  "ravendb": {
     "Urls": [
       "http://live-test.ravendb.net"
     ],


### PR DESCRIPTION
I was trying to use a different `SectionName` and it wasn't working. I switched the order of the `Configure` calls and it works now. I left the different name configuration in the sample project.